### PR TITLE
Using sorted class labels

### DIFF
--- a/biotrainer/trainers/TargetManager.py
+++ b/biotrainer/trainers/TargetManager.py
@@ -17,7 +17,7 @@ class TargetManager:
     # Optional
     class_str2int: Optional[Dict[str, int]] = None
     class_int2str: Optional[Dict[int, str]] = None
-    class_labels: Optional[Dict[str, None]] = None
+    class_labels: Optional[List[str]] = None
 
     def __init__(self, protocol: str, protein_sequences: List[SeqRecord], labels_file: Optional[str] = None):
 
@@ -37,7 +37,7 @@ class TargetManager:
                 # Infer classes from data
                 for classes in self.id2target.values():
                     class_labels_temp = class_labels_temp | set(classes)
-                self.class_labels = dict.fromkeys(sorted(class_labels_temp))
+                self.class_labels = sorted(class_labels_temp)
 
                 self.number_of_outputs = len(self.class_labels)
 
@@ -72,7 +72,7 @@ class TargetManager:
             # a) Class output
             if 'class' in protocol:
                 # Infer classes from data
-                self.class_labels = dict.fromkeys(sorted(set(self.id2target.values())))
+                self.class_labels = sorted(set(self.id2target.values()))
 
                 self.number_of_outputs = len(self.class_labels)
 


### PR DESCRIPTION
Once applied, this PR will ensure the TargetManagers self.class_labels be sorted alphabetically.

Sorting the class labels conserves order for interval-scaled multiclass prediction (1,2,3...) and guarantees a consistent mapping for the same prediction task.
Set is unordered in python, so the best alternative seems to be to use dictkeys, which are guaranteed to be sorted. That's why the type of self.class_labels had to be changed. Simply doing:
```python
self.class_labels = sorted(self.class_labels)
```
would be very rude to the typing (because sorted returns a List).
