### PR TITLE
Capitalizing validation value 

### DIFF
--- a/biotrainer/trainers/target_manager_utils.py
+++ b/biotrainer/trainers/target_manager_utils.py
@@ -19,7 +19,7 @@ def get_split_lists(id2attributes: dict) -> Tuple[List[str], List[str], List[str
             val = id2attributes[idx].get("VALIDATION")
 
             try:
-                val = eval(val)
+                val = eval(val.capitalize())
             except NameError:
                 pass
 


### PR DESCRIPTION
Changed one line:
```python
# target_manager_utils Line 22
val = eval(val.capitalize())
```
(true->True, false->False)

This avoids unnecessary errors for semantically correct files, so something like
```fasta
>Seq1 TARGET=Glob SET=train VALIDATION=false
SEQWENCE
```

is now also allowed (and doesn't cause a cryptic error message).