### PR TITLE
Adding additional logger statements for evaluation

### DIFF
--- a/biotrainer/trainers/trainer.py
+++ b/biotrainer/trainers/trainer.py
@@ -187,3 +187,6 @@ def _do_and_log_evaluation(solver, test_loader, target_manager):
     test_results['predictions'] = target_manager.revert_mappings(test_results['predictions'])
 
     output_vars['test_iterations_results'] = test_results
+
+    logger.info(f"Test set metrics: {test_results['metrics']}")
+    logger.info(f"Extensive output information can be found at {output_vars['output_dir']}/out.yml")


### PR DESCRIPTION
Once applied, the logger prints the test set metrics and the path of the output file (out.yml) once the pipeline has executed. This should improve user experience and makes clear, where extensive information can be found.

Closes #19.