### PR TITLE
Fixing missing embedder name for pre-defined embeddings

### DIFF
--- a/biotrainer/utilities/executer.py
+++ b/biotrainer/utilities/executer.py
@@ -38,6 +38,7 @@ def parse_config_file_and_execute_run(config_file_path: str):
             embeddings_file = download_embeddings(url=config["embeddings_file"], script_path=str(input_file_path))
 
         config["embeddings_file"] = str(input_file_path / embeddings_file)
+        config["embedder_name"] = "custom_embeddings"
     if "pretrained_model" in config.keys():
         config["pretrained_model"] = str(input_file_path / config["pretrained_model"])
 


### PR DESCRIPTION
Because `embedder_name` and `embeddings_file` are now mutually exclusive, this led to an error when pre-computed embeddings were provided, as the log directory for the embedder name could not be created (missing config["embedder_name"]). The functionality to create the log directory was moved from trainer to executer to check for a checkpoint for `auto_resume`.
It is now fixed by setting config["embedder_name"] to "custom_embeddings" by default.