### PR TITLE
Using time.perf_counter() instead of time.time()

### DIFF
--- a/biotrainer/trainers/embeddings.py
+++ b/biotrainer/trainers/embeddings.py
@@ -86,7 +86,7 @@ def compute_embeddings(embedder_name: str, sequence_file: str, output_dir: Path,
 def load_embeddings(embeddings_file_path: str) -> Dict[str, Any]:
     # load pre-computed embeddings in .h5 file format computed via bio_embeddings
     logger.info(f"Loading embeddings from: {embeddings_file_path}")
-    start = time.time()
+    start = time.perf_counter()
 
     # https://stackoverflow.com/questions/48385256/optimal-hdf5-dataset-chunk-shape-for-reading-rows/48405220#48405220
     embeddings_file = h5py.File(embeddings_file_path, 'r')
@@ -97,6 +97,6 @@ def load_embeddings(embeddings_file_path: str) -> Dict[str, Any]:
 
     # Logging
     logger.info(f"Read {len(id2emb)} entries.")
-    logger.info(f"Time elapsed for reading embeddings: {(time.time() - start):.1f}[s]")
+    logger.info(f"Time elapsed for reading embeddings: {(time.perf_counter() - start):.1f}[s]")
 
     return id2emb

--- a/biotrainer/trainers/trainer.py
+++ b/biotrainer/trainers/trainer.py
@@ -163,9 +163,9 @@ def training_and_evaluation_routine(
 
 
 def _do_and_log_training(solver, train_loader, val_loader):
-    start_time = time.time()
+    start_time = time.perf_counter()
     _ = solver.train(train_loader, val_loader)
-    end_time = time.time()
+    end_time = time.perf_counter()
 
     # Logging
     logger.info(f'Total training time: {(end_time - start_time) / 60:.1f}[m]')


### PR DESCRIPTION
time.perf_counter() seems to be better suited to measure relative time: https://stackoverflow.com/questions/25785243/understanding-time-perf-counter-and-time-process-time