### PR TITLE
Include output_dir as a config option

### DIFF
--- a/biotrainer/utilities/executer.py
+++ b/biotrainer/utilities/executer.py
@@ -43,7 +43,11 @@ def parse_config_file_and_execute_run(config_file_path: str):
         config["pretrained_model"] = str(input_file_path / config["pretrained_model"])
 
     # Create output directory (if necessary)
-    output_dir = input_file_path / "output"
+    if "output_dir" in config.keys():
+        output_dir = Path(config["output_dir"])
+    else:
+        output_dir = input_file_path / "output"
+        config["output_dir"] = str(output_dir)
     if not output_dir.is_dir():
         logger.info(f"Creating output dir: {output_dir}")
         output_dir.mkdir(parents=True)
@@ -68,7 +72,7 @@ def parse_config_file_and_execute_run(config_file_path: str):
         logger.info(f"Using pre_trained model: {config['pretrained_model']}")
 
     # Run biotrainer pipeline
-    out_config = training_and_evaluation_routine(output_dir=str(output_dir), log_dir=str(log_dir), **config)
+    out_config = training_and_evaluation_routine(log_dir=str(log_dir), **config)
 
     # Save output_variables in out.yml
     write_config_file(

--- a/biotrainer/utilities/executer.py
+++ b/biotrainer/utilities/executer.py
@@ -44,13 +44,13 @@ def parse_config_file_and_execute_run(config_file_path: str):
 
     # Create output directory (if necessary)
     if "output_dir" in config.keys():
-        output_dir = Path(config["output_dir"])
+        output_dir = input_file_path / Path(config["output_dir"])
     else:
         output_dir = input_file_path / "output"
-        config["output_dir"] = str(output_dir)
     if not output_dir.is_dir():
         logger.info(f"Creating output dir: {output_dir}")
         output_dir.mkdir(parents=True)
+    config["output_dir"] = str(output_dir)
 
     # Create log directory (if necessary)
     log_dir = output_dir / config["model_choice"] / config["embedder_name"]

--- a/docs/config_file_options.md
+++ b/docs/config_file_options.md
@@ -36,7 +36,7 @@ ignore_file_inconsistencies: True | False  # Default: False
 
 A concrete output directory can be specified:
 ```yaml
-output_dir: path/to/output_dir  # Default: ./output
+output_dir: path/to/output_dir  # Default: path/to/config/output
 ```
 
 ## Training data (protocol specific)

--- a/docs/config_file_options.md
+++ b/docs/config_file_options.md
@@ -34,6 +34,11 @@ If this is intended, you can tell *biotrainer* to simply ignore those redundant 
 ignore_file_inconsistencies: True | False  # Default: False
 ```
 
+A concrete output directory can be specified:
+```yaml
+output_dir: path/to/output_dir  # Default: ./output
+```
+
 ## Training data (protocol specific)
 
 Depending on the protocol that fits to your dataset, you have to provide different input files. For the data standards


### PR DESCRIPTION
This PR aims to include `output_dir` as a configuration option. If specified, it uses (creates if needed) the directory. If not specified, it works as until now, creating an `output` directory. This PR also includes a brief mention in the doc.