### PR TITLE
Renaming wrong test class name to InferencerTests

### DIFF
--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -4,7 +4,7 @@ from biotrainer.inference import Inferencer
 from bio_embeddings.embed import OneHotEncodingEmbedder
 
 
-class ConfigurationVerificationTests(unittest.TestCase):
+class InferencerTests(unittest.TestCase):
     _test_sequences = ["SEQVENCEPRTEI",
                        "SEQWENCE",
                        "PRTEIN"]


### PR DESCRIPTION
Fixing test name of InferencerTests for version 0.6.0