### PR TITLE
Use a strategy for sequence preprocessing

### DIFF
--- a/biotrainer/embedders/custom_embedder.py
+++ b/biotrainer/embedders/custom_embedder.py
@@ -35,10 +35,6 @@ class CustomEmbedder(EmbedderInterface):
         """
         raise NotImplementedError
 
-    @staticmethod
-    def _preprocess_sequences(sequences: Iterable[str]) -> List[str]:
-        raise NotImplementedError
-
     def _embed_batch(self, batch: List[str]) -> Generator[ndarray, None, None]:
         raise NotImplementedError
 

--- a/biotrainer/embedders/preprocessing_strategies.py
+++ b/biotrainer/embedders/preprocessing_strategies.py
@@ -1,0 +1,17 @@
+import re
+
+from typing import Iterable, List
+
+
+def preprocess_sequences_with_whitespaces(sequences: Iterable[str]) -> List[str]:
+    # Remove rare amino acids
+    sequences_cleaned = [re.sub(r"[UZOB]", "X", sequence) for sequence in sequences]
+    # Transformers need spaces between the amino acids
+    sequences_with_spaces = [" ".join(list(sequence)) for sequence in sequences_cleaned]
+    return sequences_with_spaces
+
+
+def preprocess_sequences_without_whitespaces(sequences: Iterable[str]) -> List[str]:
+    # Remove rare amino acids
+    sequences_cleaned = [re.sub(r"[UZOB]", "X", sequence) for sequence in sequences]
+    return sequences_cleaned


### PR DESCRIPTION
It was found that Tokenizers for different pLMs work differently under the hood, as such it was necessary to find the correct strategy to provide the sequences to the tokenizers.

ProtT5 pre-processing (https://github.com/agemagician/ProtTrans) uses whitespaces between the amino acids.
Ankh pre-processing (https://github.com/agemagician/Ankh) does not use whitespaces between the amino acids.