### PR TITLE
Adding saprot embedder example

### DIFF
--- a/examples/saprot_embedder/.gitignore
+++ b/examples/saprot_embedder/.gitignore
@@ -1,0 +1,2 @@
+output/
+out.yml

--- a/examples/saprot_embedder/README.md
+++ b/examples/saprot_embedder/README.md
@@ -1,0 +1,16 @@
+# saprot_embedder example
+
+This example shows how to use biotrainer with a structure-aware embedder called
+[SaProt](https://github.com/westlake-repl/SaProt) with the `sequence_to_class` protocol.
+It predicts a class for every sequence in the `sequences.fasta` file.
+
+The proteins are represented with both sequence and structural vocabulary,
+so the sequence appears as `MdEvVpQpLrVyQdYaKv` for example. The minor case represents the conformation of
+the corresponding residue.
+[Here](https://github.com/westlake-repl/SaProt?tab=readme-ov-file#Convert-protein-structure-into-structure-aware-sequence)
+you can find, how these structure-aware sequences are created.
+
+Execute the example (from the base directory):
+```bash
+poetry run python3 run-biotrainer.py examples/saprot_embedder/config.yml
+```

--- a/examples/saprot_embedder/config.yml
+++ b/examples/saprot_embedder/config.yml
@@ -1,0 +1,14 @@
+sequence_file: sequences.fasta
+protocol: sequence_to_class
+model_choice: FNN
+optimizer_choice: adam
+loss_choice: cross_entropy_loss
+num_epochs: 200
+use_class_weights: True
+learning_rate: 1e-3
+batch_size: 128
+save_split_ids: False
+use_half_precision: True
+device: cuda
+disable_pytorch_compile: False
+embedder_name: Takagi-san/SaProt_650M_AF2

--- a/examples/saprot_embedder/sequences.fasta
+++ b/examples/saprot_embedder/sequences.fasta
@@ -1,0 +1,8 @@
+>Seq1 TARGET=Glob SET=train
+MdEvVpQpLrVyQdYaKvKa
+>Seq2 TARGET=GlobSP SET=val
+VpQpLrVyQdYaKvYa
+>Seq3 TARGET=TM SET=test
+MdEvVpLrVyQdYaKvMa
+>Seq4 TARGET=TMSP SET=test
+MdEvQpLrVyQdYaKvEv


### PR DESCRIPTION
Once applied, this PR will add an example how to use the structure-aware embedder *SaProt*.

Embedder: https://github.com/westlake-repl/SaProt
Discussion: https://github.com/J-SNACKKB/FLIP/issues/26

Thanks to @wangjiaqi8710 for bringing this up and testing.