### PR TITLE
Adding support for ProstT5 embedder

### DIFF
--- a/biotrainer/embedders/preprocessing_strategies.py
+++ b/biotrainer/embedders/preprocessing_strategies.py
@@ -15,3 +15,14 @@ def preprocess_sequences_without_whitespaces(sequences: Iterable[str]) -> List[s
     # Remove rare amino acids
     sequences_cleaned = [re.sub(r"[UZOB]", "X", sequence) for sequence in sequences]
     return sequences_cleaned
+
+
+def preprocess_sequences_for_prostt5(sequences: Iterable[str]) -> List[str]:
+    preprocessed_sequences = preprocess_sequences_with_whitespaces(sequences)
+
+    # We have AAs, so we need to tell the model we want to translate AA->3Di.
+    # To do so, we prepend "<AA2fold>" while keeping residues in upper-case.
+    prefixed_sequences = [
+        "<AA2fold>" + " " + seq.upper() for seq in preprocessed_sequences
+    ]
+    return prefixed_sequences

--- a/docs/config_file_options.md
+++ b/docs/config_file_options.md
@@ -92,7 +92,7 @@ been deprecated as package for embeddings calculation. Instead, *biotrainer* now
 directly via [huggingface transformers](https://huggingface.co/docs/transformers/index).
 The following embedders have been successfully tested with *biotrainer*:
 ```yaml
-embedder_name: Rostlab/prot_t5_xl_uniref50 | ElnaggarLab/ankh-large | Rostlab/prot_t5_xl_bfd
+embedder_name: Rostlab/prot_t5_xl_uniref50 | ElnaggarLab/ankh-large | Rostlab/prot_t5_xl_bfd | Rostlab/ProstT5 | Takagi-san/SaProt_650M_AF2
 ```
 
 Transformer embedders provide the ability to use half-precision (float16) mode:


### PR DESCRIPTION
Once applied, this PR adds support for the ProstT5 embedder and fixes the issue that half_precision mode was ignored for huggingface transformer models. 