### PR TITLE
feat: Adding AAOntology baseline embedder

### DIFF
--- a/biotrainer/embedders/__init__.py
+++ b/biotrainer/embedders/__init__.py
@@ -8,6 +8,7 @@ from .onnx_embedder import OnnxEmbedder
 from .random_embedder import RandomEmbedder
 from .custom_tokenizer import CustomTokenizer
 from .embedder_interfaces import EmbedderInterface
+from .aa_ontology_embedder import AAOntologyEmbedder
 from .one_hot_encoding_embedder import OneHotEncodingEmbedder
 from .embedding_service import EmbeddingService, FineTuningEmbeddingService
 from .huggingface_transformer_embedder import HuggingfaceTransformerEmbedder
@@ -17,6 +18,7 @@ from ..utilities import is_device_cpu, get_logger
 __PREDEFINED_EMBEDDERS = {
     "one_hot_encoding": OneHotEncodingEmbedder,
     "random_embedder": RandomEmbedder,
+    "AAOntology": AAOntologyEmbedder,
 }
 
 logger = get_logger(__name__)
@@ -127,6 +129,8 @@ def get_predefined_embedder_names() -> List[str]:
 __all__ = [
     "EmbeddingService",
     "OneHotEncodingEmbedder",
+    "RandomEmbedder",
+    "AAOntologyEmbedder",
     "get_embedding_service",
     "get_predefined_embedder_names"
 ]

--- a/biotrainer/embedders/aa_ontology_embedder.py
+++ b/biotrainer/embedders/aa_ontology_embedder.py
@@ -1,0 +1,53 @@
+import numpy as np
+from numpy import ndarray
+from .embedder_interfaces import EmbedderInterface
+
+
+class AAOntologyEmbedder(EmbedderInterface):
+    """
+    Baseline embedder: Uses plain scales from AAOntology.
+
+    AAOntology provides amino-acid associated feature scales: https://doi.org/10.1016/j.jmb.2024.168717
+    """
+
+    name = "AAOntology"
+
+    def __init__(self):
+        # Create efficient lookup structures
+        self._setup_efficient_mapping()
+
+    def _setup_efficient_mapping(self):
+        """Setup efficient amino acid to scale mapping"""
+        import aaanalysis as aa
+
+        scales = aa.load_scales()
+
+        # Define amino acid order (including X as placeholder)
+        self.aa_order = "ACDEFGHIKLMNPQRSTVWYX"
+        self.embedding_dimension = len(scales.columns)  # Number of scales (586)
+
+        # Create mapping from amino acid to index
+        self.aa_to_index = {aa: i for i, aa in enumerate(self.aa_order)}
+
+        # Create the lookup matrix: shape (21, 586) for 20 AAs + X
+        self.lookup_matrix = np.zeros((len(self.aa_order), self.embedding_dimension), dtype=np.float32)
+
+        # Fill the lookup matrix with scale values
+        for i, aa in enumerate(self.aa_order[:-1]):  # Exclude X - only zeros
+            if aa in scales.index:
+                self.lookup_matrix[i] = scales.loc[aa].values.astype(np.float32)
+
+    def _embed_single(self, sequence: str) -> ndarray:
+        """Convert sequence to scale-based embedding"""
+        indices = np.fromiter(
+            (self.aa_to_index.get(aa, self.aa_to_index['X']) for aa in sequence),
+            dtype=np.int32
+        )
+
+        # Use advanced indexing to get scale values for each position
+        return self.lookup_matrix[indices]
+
+    @staticmethod
+    def reduce_per_protein(embedding: ndarray) -> ndarray:
+        """Returns the mean of all scale values across the sequence"""
+        return embedding.mean(axis=0)

--- a/docs/config_file_options.md
+++ b/docs/config_file_options.md
@@ -139,8 +139,12 @@ use_half_precision: True | False # Default: False
 To compute baselines, there are also predefined embedders directly included in *biotrainer*:
 
 ```yaml
-embedder_name: one_hot_encoding | random_embedder
+embedder_name: one_hot_encoding | random_embedder | AAOntology
 ```
+
+* `one_hot_encoding`: Creates one hot encodings based on the amino acid sequence
+* `random_embedder`: Generates random 128xsequence_length embedding vectors
+* `AAOntology`: Uses amino-acid associated feature scales from AAOntology: https://doi.org/10.1016/j.jmb.2024.168717
 
 If you want to use your own embedder directly in *biotrainer*, you can provide it as an onnx file. Usually, you will
 also need to provide a custom tokenizer config (see below).

--- a/docs/config_file_options_overview.md
+++ b/docs/config_file_options_overview.md
@@ -20,7 +20,7 @@ external_writer: tensorboard | none  # Default: tensorboard, none deactivates it
 input_file: path/to/input_file.fasta  # Required for all protocols (unless huggingface dataset is used)
 
 # Embeddings
-embedder_name: Rostlab/prot_t5_xl_uniref50 | ElnaggarLab/ankh-large | user/your-hf-model | one_hot_encoding | random_embedder | your_model.onnx
+embedder_name: Rostlab/prot_t5_xl_uniref50 | ElnaggarLab/ankh-large | user/your-hf-model | your_model.onnx | one_hot_encoding | random_embedder | AAOntology
 use_half_precision: True | False  # Default: False
 embeddings_file: path/to/embeddings.h5  # Optional pre-computed embeddings file
 dimension_reduction_method: umap | tsne  # Default: None, only possible for per-sequence embeddings

--- a/examples/sequence_to_value/config.yml
+++ b/examples/sequence_to_value/config.yml
@@ -8,4 +8,4 @@ use_class_weights: False
 learning_rate: 1e-3
 batch_size: 128
 device: cpu
-embedder_name: one_hot_encoding
+embedder_name: AAOntology

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "accelerate>=1.1.1",
     "h5py>=3.8.0,<4.0.0",
     "protobuf>=5.29.1",
-    "numpy==2.2.5",
+    "numpy>=2.1.3",
     "ruamel.yaml>=0.17.40,<0.18.0",
     "sentencepiece>=0.2.0",
     "scipy==1.15.2",
@@ -45,6 +45,7 @@ dependencies = [
     "cyclopts>=3.16.0",
     "appdirs>=1.4.4",
     "peft>=0.15.2",
+    "aaanalysis>=1.0.2"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Once applied, this PR adds a AAOntology baseline embedder, using Amino Acid Feature Scales from: https://doi.org/10.1016/j.jmb.2024.168717

Implemented via aaanalysis, see: https://aaanalysis.readthedocs.io/en/latest/generated/tutorial2b_scales_loader.html