### PR TITLE
fix: Fixing class weights usage

### DIFF
--- a/biotrainer/config/training_config.py
+++ b/biotrainer/config/training_config.py
@@ -60,6 +60,7 @@ def training_config(protocol: Protocol) -> Tuple[ConfigKey, List[ConfigOption]]:
             allow_hyperparameter_optimization=True,
             constraints=ConfigConstraints(
                 type=bool,
+                allowed_protocols=Protocol.classification_protocols(),
             )
         ),
         ConfigOption(

--- a/biotrainer/inference/inferencer.py
+++ b/biotrainer/inference/inferencer.py
@@ -81,7 +81,7 @@ class Inferencer:
             checkpoint_path = Path(log_dir) / Path(split_checkpoints[split_name])
 
             model = get_model(**split_config)
-            loss_function = get_loss(**split_config)
+            loss_function = get_loss(weight=iom.class_weights(), **split_config)
             optimizer = get_optimizer(model_parameters=model.parameters(),
                                       **split_config
                                       )

--- a/biotrainer/losses/__init__.py
+++ b/biotrainer/losses/__init__.py
@@ -31,16 +31,19 @@ __LOSSES = {
 
 
 def get_loss(protocol: Protocol, loss_choice: str, device: Union[str, torch.device],
-             weight: Optional[torch.Tensor] = None, **kwargs):
+             weight: Optional[torch.Tensor] = None,
+             use_class_weights: Optional[bool] = False,
+             **kwargs):
     loss = __LOSSES.get(protocol).get(loss_choice)
 
     if not loss:
         raise NotImplementedError
+
+    if use_class_weights:
+        assert weight is not None, "Weight must be provided when using class weights"
+        return loss(weight=weight).to(device)
     else:
-        if weight is not None:
-            return loss(weight=weight).to(device)
-        else:
-            return loss().to(device)
+        return loss().to(device)
 
 
 def get_available_losses_dict() -> Dict[Protocol, Dict[str, Any]]:

--- a/biotrainer/output_files/output_manager.py
+++ b/biotrainer/output_files/output_manager.py
@@ -198,6 +198,13 @@ class InferenceOutputManager(OutputManager):
                 return finetuning_path
         return None
 
+    def class_weights(self):
+        class_weights = self._derived_values.get("computed_class_weights", None)
+        # Restore sorting of class weights (are sorted by ascending index from class_int2str)
+        if class_weights is not None:
+            class_weights = torch.tensor([class_weights[idx] for idx in range(len(class_weights))])
+        return class_weights
+
 """ 
 TODO Is removing split ids still necessary?
 #with tempfile.TemporaryDirectory() as tmp_dir_name:

--- a/examples/inference/predict.py
+++ b/examples/inference/predict.py
@@ -15,7 +15,7 @@ def inference():
     embedder = OneHotEncodingEmbedder()
     embeddings = list(embedder.embed_many(sequences))
     # Note that for per-sequence embeddings, you would have to reduce the embeddings now:
-    # embeddings = [[embedder.reduce_per_protein(embedding)] for embedding in embeddings]
+    # embeddings = [embedder.reduce_per_protein(embedding) for embedding in embeddings]
     predictions = inferencer.from_embeddings(embeddings, split_name="hold_out")
     for sequence, prediction in zip(sequences, predictions["mapped_predictions"].values()):
         print(sequence)


### PR DESCRIPTION
Once applied, this PR fixes class weights usage for both training and inference. At the moment, class_weights were always used, regardless of the value of the `use_class_weights` config option.