### PR TITLE
docs: fix bootstrapping result access in intro tutorial

### DIFF
--- a/examples/tutorials/biotrainer_intro_compare.ipynb
+++ b/examples/tutorials/biotrainer_intro_compare.ipynb
@@ -165,8 +165,9 @@
    "source": [
     "# First we get the bootstrapping results\n",
     "bootstrapping_ohe_dict = results[\"test_results\"][\"test\"][\"bootstrapping\"]\n",
-    "ohe_rmse_mean = bootstrapping_ohe_dict[\"rmse\"][\"mean\"]\n",
-    "ohe_rmse_ci = (bootstrapping_ohe_dict[\"rmse\"][\"upper\"] - bootstrapping_ohe_dict[\"rmse\"][\"lower\"]) / 2  # Assuming about symmetrical bounds\n",
+    "ohe_rmse_result = [res for res in bootstrapping_ohe_dict[\"results\"] if res[\"name\"] == \"rmse\"][0]\n",
+    "ohe_rmse_mean = ohe_rmse_result[\"mean\"]\n",
+    "ohe_rmse_ci = (ohe_rmse_result[\"upper\"] - ohe_rmse_result[\"lower\"]) / 2  # Assuming about symmetrical bounds\n",
     "\n",
     "# Now let's compare them!\n",
     "print(f\"ProtT5: RMSE Mean: {prott5_rmse_mean} CI: {prott5_rmse_ci}\")\n",
@@ -251,3 +252,4 @@
  "nbformat": 4,
  "nbformat_minor": 5
 }
+


### PR DESCRIPTION
The train() function output structure has changed, causing a KeyError in the intro tutorial when accessing bootstrapping results.

Changes:
Updated biotrainer_intro_compare.ipynb to find the rmse metric within the new results list structure.

--> Fixes the tutorial for the current version of biotrainer.