### PR TITLE
Fix dead neptune.ai cross-validation link in config docs

### DIFF
--- a/docs/config_file_options.md
+++ b/docs/config_file_options.md
@@ -345,7 +345,7 @@ This is the default option and specifying it in the config file is optional.
 Additionally, *biotrainer* supports a set of other cross validation methods, which can be configured in the
 configuration file, as shown in the next sections. We assume knowledge of the methods and only provide the available
 configuration options.
-[This article](https://neptune.ai/blog/cross-validation-in-machine-learning-how-to-do-it-right) provides a more
+[This article](https://web.archive.org/web/20251006185719/https://neptune.ai/blog/cross-validation-in-machine-learning-how-to-do-it-right) provides a more
 in-depth description of the implemented cross validation methods.
 
 ### k-fold Cross Validation


### PR DESCRIPTION
neptune.ai was acquired by OpenAI in December 2025 and the entire blog now 308-redirects to a press-release page, so the neptune.ai/blog link(s) below no longer lead to the referenced article(s).

This PR fixes 1 dead link in `docs/config_file_options.md` ("This article provides a more…"), pointing it to the Wayback Machine snapshot of the original article the text refers to.
All archive links are pinned to the last working (HTTP 200) Wayback capture before the redirect took effect.