### PR TITLE
feat: Batching masked-marginals forward passes for zero-shot scoring

### DIFF
--- a/biotrainer/bioengineer/bioengineer.py
+++ b/biotrainer/bioengineer/bioengineer.py
@@ -73,7 +73,8 @@ class BioEngineer:
     def zero_shot_masked_marginals(self,
                                    wt_sequence: str,
                                    mutations: List[str],
-                                   one_indexed: Optional[bool] = True) -> List[VariantScore]:
+                                   one_indexed: Optional[bool] = True,
+                                   batch_size: int = 32) -> List[VariantScore]:
         """
         Compute zero-shot masked marginals for specific mutations in the given sequence.
         All positions in the sequence are masked sequentially.
@@ -83,13 +84,14 @@ class BioEngineer:
         :param mutations: List of mutations: Can be single mutations ('A15G')
                 or multiple mutations separated by ':' ('A15G:L20P')
         :param one_indexed: Offset for mutation positions (1-indexed by default)
+        :param batch_size: Number of masked positions to score per forward pass
 
         :return: List of scores or probabilities associated with the specified
             mutations in the sequence.
         :raises:
             NotImplementedError: If masked logits calculation is not available
         """
-        return self.model_wrapper.zero_shot_masked_marginals(wt_sequence, mutations, one_indexed)
+        return self.model_wrapper.zero_shot_masked_marginals(wt_sequence, mutations, one_indexed, batch_size)
 
     def zero_shot_pseudoperplexity(self,
                                    wt_sequence: str,

--- a/biotrainer/bioengineer/bioengineer_baselines.py
+++ b/biotrainer/bioengineer/bioengineer_baselines.py
@@ -39,7 +39,7 @@ class ConstantEngineerBaseline(BioEngineerModelWrapper):
     def _get_log_probabilities(self, sequence: str) -> torch.Tensor:
         return torch.full((len(sequence), 20), fill_value=self._log_prob, device=torch.device("cpu"))
 
-    def _get_masked_log_probabilities(self, sequence: str) -> torch.Tensor:
+    def _get_masked_log_probabilities(self, sequence: str, batch_size: int = 32) -> torch.Tensor:
         return torch.full((len(sequence), 20), fill_value=self._log_prob, device=torch.device("cpu"))
 
     def _compute_pseudoperplexity(self, sequence: str) -> float:
@@ -110,7 +110,7 @@ class RandomEngineerBaseline(BioEngineerModelWrapper):
 
         return log_probs
 
-    def _get_masked_log_probabilities(self, sequence: str) -> torch.Tensor:
+    def _get_masked_log_probabilities(self, sequence: str, batch_size: int = 32) -> torch.Tensor:
         """
         For random baseline, masked-marginals same as wt-marginals.
         (No actual model to condition on context)

--- a/biotrainer/bioengineer/bioengineer_interfaces.py
+++ b/biotrainer/bioengineer/bioengineer_interfaces.py
@@ -51,7 +51,7 @@ class BioEngineerModelWrapper(ABC, BiotrainerTokenizerMixin):
         raise NotImplementedError
 
     @abstractmethod
-    def _get_masked_log_probabilities(self, sequence: str) -> torch.Tensor:
+    def _get_masked_log_probabilities(self, sequence: str, batch_size: int = 32) -> torch.Tensor:
         """
         Get log probabilities for all positions using the masked-marginals strategy.
         Each position is masked independently and scored.
@@ -135,7 +135,8 @@ class BioEngineerModelWrapper(ABC, BiotrainerTokenizerMixin):
     def zero_shot_masked_marginals(self,
                                    wt_sequence: str,
                                    mutations: List[str],
-                                   one_indexed: Optional[bool] = True) -> List[VariantScore]:
+                                   one_indexed: Optional[bool] = True,
+                                   batch_size: int = 32) -> List[VariantScore]:
         """
         Score mutations using the masked-marginals strategy.
         Each position is independently masked and predicted.
@@ -144,11 +145,12 @@ class BioEngineerModelWrapper(ABC, BiotrainerTokenizerMixin):
             wt_sequence: Wild-type protein sequence
             mutations: List of mutations to score
             one_indexed: Whether mutation positions are 1-indexed
+            batch_size: Number of masked positions to score per forward pass
 
         Returns:
             List of VariantScore objects
         """
-        log_probs = self._get_masked_log_probabilities(wt_sequence)
+        log_probs = self._get_masked_log_probabilities(wt_sequence, batch_size)
         return self._score_variants_from_marginal_probabilities(wt_sequence, log_probs, mutations, one_indexed,
                                                                 ZeroShotMethod.MASKED_MARGINALS)
 
@@ -289,14 +291,12 @@ class BertLikeEngineer(BioEngineerModelWrapper, ABC):
         windowed_mask = attention_mask[:, start:end] if attention_mask is not None else None
         return start, end, windowed_tokens, windowed_mask
 
-    def _get_masked_log_probabilities(self, sequence: str) -> torch.Tensor:
+    def _get_masked_log_probabilities(self, sequence: str, batch_size: int = 32) -> torch.Tensor:
         # Tokenize the sequence
         tokenized_sequences, attention_mask = self._tokenize([sequence], preprocess=True)
 
         # Get mask token ID
         mask_token_id = self.get_mask_token_id()
-
-        all_token_probs = []
 
         # Iterate through all positions (excluding BOS and EOS)
         # tokenized_sequences[0, 0] = BOS
@@ -304,25 +304,46 @@ class BertLikeEngineer(BioEngineerModelWrapper, ABC):
         # tokenized_sequences[0, -1] = EOS
         seq_len = tokenized_sequences.size(1)
 
-        for i in tqdm(range(seq_len), desc="Computing masked probabilities", unit="pos", ncols=100, leave=False):
+        # Collect the scoring window of every masked position. get_optimal_window returns windows of uniform width
+        # within a sequence, so all masked variants stack into a single [seq_len, window_size] tensor.
+        windowed_tokens, windowed_masks, masked_positions = [], [], []
+        for i in range(seq_len):
             # Clone and mask position i
             batch_tokens_masked = tokenized_sequences.clone()
             batch_tokens_masked[0, i] = mask_token_id
 
             # Get optimal window
-            start, end, windowed_tokens, windowed_mask = self._get_windowed_tokens(batch_tokens_masked, attention_mask,
-                                                                                   masked_position=i,
-                                                                                   seq_len_with_special=seq_len)
-            logits = self._model_forward_fn(input_ids=windowed_tokens,
-                                            attention_mask=windowed_mask)  # [seq_len, vocab_size] without EOS/BOS
+            start, end, window_tokens, window_mask = self._get_windowed_tokens(batch_tokens_masked, attention_mask,
+                                                                              masked_position=i,
+                                                                              seq_len_with_special=seq_len)
+            windowed_tokens.append(window_tokens[0])
+            windowed_masks.append(window_mask[0] if window_mask is not None else None)
+            masked_positions.append(i - start)
 
-            # Get log probabilities for the masked position
-            token_position = i - start
-            token_logits = logits[token_position]  # [vocab_size]
-            all_token_probs.append(token_logits.cpu())
+        windowed_tokens = torch.stack(windowed_tokens, dim=0)  # [seq_len, window_size]
+        windowed_masks = None if windowed_masks[0] is None else torch.stack(windowed_masks, dim=0)
+        masked_positions = torch.tensor(masked_positions)
 
-        # Stack all position logits: [seq_len, vocab_size]
-        logits = torch.stack(all_token_probs, dim=0)
+        # The masked positions are scored independently of each other, so their forward passes can be batched
+        token_splits = torch.split(windowed_tokens, batch_size)
+        mask_splits = torch.split(windowed_masks, batch_size) if windowed_masks is not None else [None] * len(
+            token_splits)
+        position_splits = torch.split(masked_positions, batch_size)
+
+        all_token_probs = []
+        for batch_tokens, batch_mask, batch_positions in tqdm(zip(token_splits, mask_splits, position_splits),
+                                                              desc="Computing masked probabilities", unit="batch",
+                                                              total=len(token_splits), ncols=100, leave=False):
+            logits = self._model_batched_forward_fn(input_ids=batch_tokens,
+                                                    attention_mask=batch_mask)  # [batch, window_size, vocab_size]
+
+            # Get the logits of every window at its own masked position
+            batch_positions = batch_positions.to(logits.device)
+            batch_indices = torch.arange(batch_positions.size(0), device=logits.device)
+            all_token_probs.append(logits[batch_indices, batch_positions].cpu())  # [batch, vocab_size]
+
+        # Concatenate all position logits: [seq_len, vocab_size]
+        logits = torch.cat(all_token_probs, dim=0)
 
         # Use full vocabulary for probabilities (ProteinGym approach)
         log_probs = torch.log_softmax(logits, dim=-1)
@@ -381,7 +402,7 @@ class GPTLikeEngineer(BioEngineerModelWrapper, ABC):
     def _get_log_probabilities(self, sequence: str):
         raise NotImplementedError("WT marginals are not defined for causal LMs")
 
-    def _get_masked_log_probabilities(self, sequence: str):
+    def _get_masked_log_probabilities(self, sequence: str, batch_size: int = 32):
         raise NotImplementedError("Masked marginals are not defined for causal LMs")
 
     def _compute_pseudoperplexity(self, sequence: str) -> float:

--- a/tests/test_bioengineer.py
+++ b/tests/test_bioengineer.py
@@ -1,13 +1,63 @@
+import torch
 import unittest
 
 from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 
 from biotrainer_core.data_classes import ZeroShotMethod, Variant
 from biotrainer.bioengineer import BioEngineer, BioEngineerBaseline
+from biotrainer.bioengineer.bioengineer_interfaces import BertLikeEngineer
+
+_VOCAB_SIZE = 25
+_MASK_TOKEN_ID = 24
+
+
+class _DeterministicModel(torch.nn.Module):
+    """ Model whose logits depend only on the token at a position, so that batching cannot change the result """
+
+    def forward(self, input_ids: torch.Tensor, attention_mask: Optional[torch.Tensor] = None):
+        vocab = torch.arange(_VOCAB_SIZE, dtype=torch.float32).view(1, 1, -1)
+        logits = torch.sin(input_ids.unsqueeze(-1).float() * (vocab + 1.0))
+        return type("Output", (), {"logits": logits})
+
+
+class _DeterministicEngineer(BertLikeEngineer):
+    """ BertLikeEngineer over a deterministic model, to test masked-marginals without downloading weights """
+
+    def __init__(self):
+        super().__init__(name="deterministic", model=_DeterministicModel(), tokenizer=None,
+                         device=torch.device("cpu"))
+
+    @classmethod
+    def detect(cls, embedder_name: str, device: torch.device):
+        return None
+
+    def _tokenize(self, batch: List[str], preprocess: Optional[bool] = False) -> Tuple[torch.Tensor, torch.Tensor]:
+        token_ids = [[0] + [1 + (ord(aa) % 20) for aa in batch[0]] + [1]]
+        tokenized_sequences = torch.tensor(token_ids)
+        return tokenized_sequences, torch.ones_like(tokenized_sequences)
+
+    def get_mask_token_id(self) -> Optional[int]:
+        return _MASK_TOKEN_ID
+
+    def aa_to_idx(self) -> Dict[str, int]:
+        return {}
 
 
 class BioEngineerTests(unittest.TestCase):
     error_tolerance = 0.01
+
+    def test_masked_marginals_batching(self):
+        """ Batched masked-marginals scoring must be equivalent to scoring one masked position at a time """
+        engineer = _DeterministicEngineer()
+        sequence = "MAGSMALMKQWERTYIPDFNHCV" * 3
+
+        unbatched = engineer._get_masked_log_probabilities(sequence, batch_size=1)
+        batched = engineer._get_masked_log_probabilities(sequence, batch_size=32)
+
+        self.assertEqual(batched.shape, (len(sequence), _VOCAB_SIZE))
+        self.assertTrue(torch.equal(batched, unbatched),
+                        "Batched masked-marginals differ from the unbatched reference!")
 
     def test_baselines(self):
         """ Test BioEngineer baselines on protein gym dataset """


### PR DESCRIPTION
Masked-marginals scores every position from its own forward pass with that position masked. Those passes are independent of each other, but they were run one at a time, so a 200-residue protein meant 200 batch-1 forwards.

This stacks the per-position masked windows and runs them through `_model_batched_forward_fn` in batches of `batch_size` (default 32, same default as the categorical Jacobian). `get_optimal_window` returns windows of uniform width within a sequence, so the masked variants stack without padding.

ESM-2 650M on a GH200, scoring `B2L11_HUMAN_Dutta_2010_binding-Mcl-1` (198 residues, 170 variants, the assay already in `tests/`):

| | `batch_size=1` | `batch_size=32` |
|---|---|---|
| masked-marginals | 4.90s | 1.31s (3.7x) |
| end-to-end assay | 5.24s | 1.47s (3.6x) |

SCC 0.2588 and NDCG 0.4719 in both cases. Largest difference in the log probabilities is 9.7e-5, which is float GEMM reduction order.

Pseudo-perplexity calls the same function once per variant, so it gets the speedup too.

Added `test_masked_marginals_batching`, which asserts the batched result is bit-identical to `batch_size=1` using a deterministic dummy model, so it runs on CPU without downloading weights.

Draft because I would like a second opinion on whether `batch_size` should also be threaded through `zero_shot_pseudoperplexity` and `rank_pgym_dataset`, or left at the default there as it is here.