### PR TITLE
configurable batch size and cached aggregation bug fix in contact task

### DIFF
--- a/biotrainer/autoeval/autoeval.py
+++ b/biotrainer/autoeval/autoeval.py
@@ -306,12 +306,13 @@ class AutoEval:
                                                                          )
         return self
 
-    def pbc_zeroshot_contact(self, zero_shot_method: ZeroShotMethod = ZeroShotMethod.JACOBIAN_CONTACT):
+    def pbc_zeroshot_contact(self, zero_shot_method: ZeroShotMethod = ZeroShotMethod.JACOBIAN_CONTACT, batch_size: int = 32):
         """
         Add PBC zero-shot contact prediction evaluation tasks to the AutoEval pipeline.
 
         :param zero_shot_method: The zero-shot method to use for contact prediction. 
             Defaults to ZeroShotMethod.JACOBIAN_CONTACT.
+        :param batch_size: Batch size to be used when computing the categorical Jacobian.
         :return: The AutoEval instance for method chaining.
         """
         framework_obj, maybe_framework_result, output_dir = self._general_task_setup(
@@ -333,6 +334,7 @@ class AutoEval:
                 bioengineer=bioengineer,
                 device=runner_params.device,
                 development_mode=self.development_mode,
+                batch_size=batch_size,
             )
 
         self._frameworks_to_runners[framework_obj] = _AutoEvalTaskRunner(framework=framework_obj,

--- a/biotrainer/autoeval/pipelines/autoeval_zeroshot_contact.py
+++ b/biotrainer/autoeval/pipelines/autoeval_zeroshot_contact.py
@@ -23,6 +23,7 @@ def autoeval_zeroshot_contact_pipeline(framework: AutoEvalFramework,
                                        bioengineer: Optional[BioEngineer],
                                        development_mode: bool,
                                        device=None,
+                                       batch_size: int = 32,
                                        ):
     assert bioengineer is not None, f"BioEngineer could not be initialized for embedder {embedder_name}!"
 
@@ -95,24 +96,27 @@ def autoeval_zeroshot_contact_pipeline(framework: AutoEvalFramework,
                                                 predict_func=lambda
                                                     seq_record: bioengineer.zero_shot_contact_map(
                                                     method=zero_shot_method,
-                                                    sequence=seq_record.seq),
+                                                    sequence=seq_record.seq,
+                                                    batch_size=batch_size),
                                                 get_ground_truth_func=load_gt_contact_map,
                                                 get_seq_id_func=lambda d: d.seq_id,
                                                 cached_results=cached_results,
                                                 )
 
         # Run Evaluation of zero-shot contact maps
-        single_results = []
+        # Start from this dataset's cached results and add newly computed ones,
+        # so that aggregation is correct and uses previous cache-hits too (e.g. re-run, or ids overlapping across datasets).
+        dataset_protein_results: Dict[str, ContactSingleProteinResult] = dict(cached_results)
         for single_result in evaluate():
             zero_shot_contact_cached_results.update_and_sync(result=single_result,
                                                              output_dir=output_dir)
-            single_results.append(single_result)
+            dataset_protein_results[single_result.protein_name] = single_result
 
         dataset_result, dataset_result_dev = get_dataset_and_dev_result_from_single_contact_results(dataset_name=dataset_name,
-                                                                                                    single_results=single_results,
+                                                                                                    single_results=list(dataset_protein_results.values()),
                                                                                                     development_ids=development_ids)
         zero_shot_contact_framework_report.update_result(task_name=dataset_name,
-                                                         per_protein_results=zero_shot_contact_cached_results.per_protein_results,
+                                                         per_protein_results=dataset_protein_results,
                                                          dataset_result=dataset_result,
                                                          dataset_result_dev=dataset_result_dev)
 


### PR DESCRIPTION
Two changes in contact task pipeline:
1. batch_size used in computation of contact map now configurable from autoeval layer
2. bug fix in aggregation of cached contact results